### PR TITLE
gitignore 에 jpa buddy 플러그인의 설정 파일을 무시하도록 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 ### Querydsl ###
 /src/main/generated
 
+### Jpa buddy ###
+.jpb
+
 ### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839


### PR DESCRIPTION
JPA buddy 플러그인 설정으로 생겨난 디렉토리를 무시하도록 `.gitignore` 파일 수정

Resolved: #20 